### PR TITLE
Remove codecov orb from circleci for now.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   python: circleci/python@0.2.1
-  codecov: codecov/codecov@1.0.1
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This will be integrated later on, right now it is a low priority and it is keeping our tests on CircleCI from running on our master branch.